### PR TITLE
Use SSL for links and assets where possible

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,114 +1,114 @@
-        </div>  
+        </div>
 
             </div>
 
             <div id="sidebar">
-                
-               <div class="widget widget_recent_entries">  
+
+               <div class="widget widget_recent_entries">
                      <center>
                         <table width="250" align="center">
                         <tbody>
                             <tr>
-                                <td align="center"><a href="http://bit.ly/1oCl65e" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/events/api-strategy-practice-chicago/api-strategy-practice-chicago-logo.png" width="250" style="border: 0px solid #000;" /></a></td>
+                                <td align="center"><a href="https://bit.ly/1oCl65e" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/events/api-strategy-practice-chicago/api-strategy-practice-chicago-logo.png" width="250" style="border: 0px solid #000;" /></a></td>
                             </tr>
                         </tbody>
-                        </table>                     
+                        </table>
                      </center>
-                 </div> 
+                 </div>
 
-                 <div class="widget widget_recent_entries">  
+                 <div class="widget widget_recent_entries">
                      <h3>Winning in the API Economy</h3>
                      <center>
                         <table width="250" align="center">
                         <tbody>
                             <tr>
-                                <td align="center"><a href="http://bit.ly/1cHBhd5" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/api-service-providers/3Scale/ebook-3scale.png" width="200" style="border: 0px solid #000;" /></a></td>
+                                <td align="center"><a href="https://bit.ly/1cHBhd5" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/api-service-providers/3Scale/ebook-3scale.png" width="200" style="border: 0px solid #000;" /></a></td>
                             </tr>
                             <tr>
-                                <td align="center"><strong><a href="http://bit.ly/1cHBhd5" target="_blank">Download as PDF</a></strong></td>
+                                <td align="center"><strong><a href="https://bit.ly/1cHBhd5" target="_blank">Download as PDF</a></strong></td>
                             </tr>
                         </tbody>
-                        </table>                     
+                        </table>
                      </center>
-                 </div>           
-                 
-                 <div class="widget widget_recent_entries">  
+                 </div>
+
+                 <div class="widget widget_recent_entries">
                      <h3>API Commons</h3>
                      <center>
                         <table width="250" align="center">
                         <tbody>
                             <tr>
-                                <td align="center"><a href="http://bit.ly/1e27KIc" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/api-commons/api-commons-icon.png" width="150" style="border: 0px solid #000;" /></a></td>
+                                <td align="center"><a href="https://bit.ly/1e27KIc" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/api-commons/api-commons-icon.png" width="150" style="border: 0px solid #000;" /></a></td>
                             </tr>
                         </tbody>
-                        </table>                     
+                        </table>
                      </center>
-                 </div> 
-                 
+                 </div>
+
                 <!--- Begin Partners --->
-                <div class="widget widget_recent_entries">  
-                 
-                    <script id="parterListingTemplate" type="text/template"> 
-                        {% raw  %}  
+                <div class="widget widget_recent_entries">
+
+                    <script id="parterListingTemplate" type="text/template">
+                        {% raw  %}
                         <a href="{{url}}" target="_blank" title="{{title}}">
                         <img src="{{logo}}" width="{{width}}" style="padding-bottom: {{paddingbottom}}px;" />
-                        </a>   
-                        {% endraw %}                                                                                                                    
-                    </script>  
-                     
+                        </a>
+                        {% endraw %}
+                    </script>
+
                     <script type="text/javascript">
                     function listSponsors()
                         {
-                        $.getJSON('/data/sponsors.json', function(data) {               
-                            $.each(data['sponsors'], function(key, val) {                  
+                        $.getJSON('/data/sponsors.json', function(data) {
+                            $.each(data['sponsors'], function(key, val) {
                             var template = $('#parterListingTemplate').html();
                             var html = Mustache.to_html(template, val);
                             $('#partnerListingContainer').append(html);
-                            });         
-                        });             
-                    }    
+                            });
+                        });
+                    }
                     </script>
-                       
+
                     <h3>Partner Sites</h3>
                     <div id="partnerListingContainer" align="center"><br /><br /> </div>
-                    
+
                     <script type="text/javascript">
                         listSponsors();
-                    </script>                    
-                
-                </div>  
-                <!--- End Partners --->                                                  
-                          
+                    </script>
+
+                </div>
+                <!--- End Partners --->
+
                 {% if page.title == 'API Evangelist' %}
-                 <div class="widget widget_recent_entries">  
+                 <div class="widget widget_recent_entries">
                      <h3>API 101</h3>
                      <center>
                         <table width="250" align="center">
                         <tbody>
                             <tr>
-                                <td align="center"><a href="http://bit.ly/15xIQwI" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/whitepapers/api-evangelist-api-101-white-paper-2.png" width="200" style="border: 0px solid #000;" /></a></td>
+                                <td align="center"><a href="https://bit.ly/15xIQwI" target="_blank"><img src="https://s3.amazonaws.com/kinlane-productions/whitepapers/api-evangelist-api-101-white-paper-2.png" width="200" style="border: 0px solid #000;" /></a></td>
                             </tr>
                             <tr>
-                                <td align="center"><strong><a href="http://bit.ly/15xIQwI" target="_blank">Download as PDF</a></strong></td>
+                                <td align="center"><strong><a href="https://bit.ly/15xIQwI" target="_blank">Download as PDF</a></strong></td>
                             </tr>
                         </tbody>
-                        </table>                     
+                        </table>
                      </center>
-                 </div>  
-                {% endif %}                               
-                
-                <div class="widget widget_recent_entries">  
+                 </div>
+                {% endif %}
+
+                <div class="widget widget_recent_entries">
                     <h3>Latest Blog Posts</h3>
-                    <ul>                
-                    
+                    <ul>
+
                         {% for post in site.posts limit:25 %}
-                            <li><a href="{{ post.url }}">{{ post.title }}</a></li>    
-                        {% endfor %}   
-                                    
+                            <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+                        {% endfor %}
+
                      </ul>
-                </div>    
-                
-                <div class="widget widget_recent_entries">                 
+                </div>
+
+                <div class="widget widget_recent_entries">
                     <script>
                       (function() {
                         var cx = '018257313084406466253:3xv2giv8meg';
@@ -121,42 +121,42 @@
                         s.parentNode.insertBefore(gcse, s);
                       })();
                     </script>
-                    <gcse:search></gcse:search>                
-                </div>                                                       
-                           
+                    <gcse:search></gcse:search>
+                </div>
+
             </div>
 
-        </div><!-- /#main-sidebar-container -->         
+        </div><!-- /#main-sidebar-container -->
 
     </div>
 
     <div id="footer" class="col-full">
 
         <div id="copyright" class="col-left">
-            <p><a rel="license" href="http://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a></p>        
+            <p><a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a></p>
         </div>
 
         <div id="credit" class="col-right">
-    
-            <p><a href="http://kinlane.com/about/">About</a></p>    
+
+            <p><a href="http://kinlane.com/about/">About</a></p>
             <p>|</p>
-            <p><a href="http://apievangelist.com">API Evangelist</a></p>        
+            <p><a href="http://apievangelist.com">API Evangelist</a></p>
             <p>|</p>
             <p><a href="http://apivoice.com">API Voice</a></p>
             <p>|</p>
             <p><a href="http://apicommons.org/">API Commons</a></p>
             <p>|</p>
-            <p><a href="http://apisjson.org/">APIs.json</a></p>            
-            <p>|</p>            
-            <p><a href="http://kinlane.com/contact/">Contact</a></p>                
-        
+            <p><a href="http://apisjson.org/">APIs.json</a></p>
+            <p>|</p>
+            <p><a href="http://kinlane.com/contact/">Contact</a></p>
+
         </div>
 
     </div><!-- /#footer  -->
 
-</div><!-- /#wrapper -->     
+</div><!-- /#wrapper -->
 
-<a href="https://plus.google.com/102765731413927656691" rel="publisher">Google+</a>             
+<a href="https://plus.google.com/102765731413927656691" rel="publisher">Google+</a>
 
 <script type="text/javascript">
 
@@ -170,7 +170,7 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
-  
+
   function checkLinkRot()
     {
     var linkArray = [];
@@ -179,26 +179,26 @@
         linkArray.push(links[i].href);
     }
     url = "http://linkrot.api.laneworks.net/v1/links/";
-    var myJsonString = JSON.stringify(linkArray);                
+    var myJsonString = JSON.stringify(linkArray);
     $.ajax({
         type: "POST",
         url: url,
         data: myJsonString,
-        success: function (data) {            
-             $.each(data, function($Key,$Value) {                 
+        success: function (data) {
+             $.each(data, function($Key,$Value) {
                 $URL = $Value['URL'];
-                $returnURL = $Value['returnURL'];  
+                $returnURL = $Value['returnURL'];
                 var links = document.getElementsByTagName("a");
                 for(var i=0; i<links.length; i++) {
                     if(links[i].href==$URL)
                         {
-                        document.getElementsByTagName("a")[i].href=$returnURL;    
+                        document.getElementsByTagName("a")[i].href=$returnURL;
                         }
-                     }                
-             });                 
+                     }
+             });
         }
-    });                
-    }   
+    });
+    }
 
 </script>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,11 @@
 <a href="https://github.com/kinlane/api-evangelist"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
 <div id="wrapper">
-    
+
      <div id="header" class="col-full">
-        <div id="logo"><a href="http://apievangelist.com/" title="API Evangelist"><img src="http://kinlane-productions.s3.amazonaws.com/api-evangelist/api-evangelist-logo-400.png"></a></div> 
-        
+        <div id="logo"><a href="http://apievangelist.com/" title="API Evangelist"><img src="https://kinlane-productions.s3.amazonaws.com/api-evangelist/api-evangelist-logo-400.png"></a></div>
+
     </div>
-    
+
     <div id="navigation" class="col-full">
 
         <ul id="main-nav" class="nav fl">
@@ -21,31 +21,31 @@
          </ul>
 
         <ul class="rss fr">
-            <li class="sub-rss">                
+            <li class="sub-rss">
                 <a href="mailto:info@apievangelist.com">
-                    <img src="https://s3.amazonaws.com/kinlane-productions/icon-set-roundedcorners/gmail-icon.png" width="28" />
+                    <img src="https://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/gmail-icon.png" width="28" />
                 </a>
-            </li>   
+            </li>
             <li class="sub-rss">
                 <a href="http://feeds.feedburner.com/ApiEvangelist" target="_blank">
-                    <img src="http://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/rss.png" />
-                </a>           
+                    <img src="https://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/rss.png" />
+                </a>
             </li>
-            <li class="sub-rss">                
-                <a href="https://twitter.com/#!/kinlane" target="_blank">
-                    <img src="http://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/twitter.png" />
+            <li class="sub-rss">
+                <a href="https://twitter.com/kinlane" target="_blank">
+                    <img src="https://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/twitter.png" />
                 </a>
             </li>
             <li class="sub-rss">
                 <a href="http://www.linkedin.com/in/kinlane" target="_blank">
-                    <img src="http://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/linkedin.png" />
+                    <img src="https://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/linkedin.png" />
                 </a>
             </li>
             <li class="sub-rss">
                 <a href="https://plus.google.com/106460238807821851374" target="_blank">
-                    <img src="http://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/google.png" />
+                    <img src="https://kinlane-productions.s3.amazonaws.com/icon-set-roundedcorners/google.png" />
                 </a>
-            </li>           
+            </li>
         </ul>
 
     </div>
@@ -55,7 +55,7 @@
         <div id="main-sidebar-container">
 
             <!-- #main Starts -->
-            <div id="main">      
-                                
+            <div id="main">
+
                 <!-- Post Starts -->
-                <div class="post-1 post type-post hentry category-api-marketplace category-uncategorized"> 
+                <div class="post-1 post type-post hentry category-api-marketplace category-uncategorized">

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -5,12 +5,12 @@
   <title>{{ page.title }}</title>
 
   <link href="{{ site.url }}/css/style.css" rel="stylesheet" type="text/css" media="all">
-    
-  <script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>   
+
+  <script src="https://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
   <script src="/js/mustache.js" type="text/javascript"></script>
 
   <style type="text/css">
-  
+
     #logo .site-title, #logo .site-description { display:block; }
     body {background-repeat:no-repeat;background-position:top center;border-top:4px solid #000000;}
     #header {background-repeat:repeat;background-position:top center;margin-top:0px;margin-bottom:0px;padding-top:20px;padding-bottom:15px;border:0px solid ;}
@@ -26,84 +26,84 @@
     .nav-entries, .wp-pagenavi {border-top:1px solid #e6e6e6;border-bottom:4px solid #e6e6e6;}
     .nav-entries a, .wp-pagenavi a:link, .wp-pagenavi a:visited, .wp-pagenavi .current, .wp-pagenavi .on, .wp-pagenavi a:hover, .wp-pagenavi span.extend, .wp-pagenavi span.pages {font:italic 12px/1.5em Georgia, serif;color:#777777!important}
     .wp-pagenavi a:link, .wp-pagenavi a:visited, .wp-pagenavi span.extend, .wp-pagenavi span.pages, .wp-pagenavi span.current {color:#777777!important}
-    
+
     .widget h3 {font:bold 14px/1.5em Arial, sans-serif;color:#555555;border-bottom:3px solid #e6e6e6;}
     .widget_recent_comments li, #twitter li { border-color: #e6e6e6;}
-    
+
     .widget p, .widget .textwidget {font:normal 12px/1.5em Arial, sans-serif;color:#555555;}
     .widget {font:normal 12px/1.5em Arial, sans-serif;color:#555555;border-radius:0px;-moz-border-radius:0px;-webkit-border-radius:0px;}
-    
+
     .widget ul{
         margin-left: 35px;
         list-style: disc;
     }
-    
+
     .nav a, #navigation ul.rss a {font:normal 14px Arial, sans-serif;color:#555555}
     #navigation {border-top:1px solid #dbdbdb;border-bottom:4px solid #dbdbdb;border-left:0px solid #dbdbdb;border-right:0px solid #dbdbdb;border-radius:0px; -moz-border-radius:0px; -webkit-border-radius:0px;}
     #footer, #footer p {font:italic 14px Georgia, serif;color:#777777}
     #footer {border-top:4px solid #dbdbdb;border-bottom:0px solid ;border-left:0px solid ;border-right:0px solid ;border-radius:0px; -moz-border-radius:0px; -webkit-border-radius:0px;}
-    
+
     .bodycontent{
         margin: 8px 0 8px 40px;
         padding: 0px 0px 0px 0px;
         }
-        
+
      p
         {
-        padding: 2px;   
+        padding: 2px;
         }
-    
+
     blockquote
         {
-        margin-left: 30px;  
+        margin-left: 30px;
         margin-right: 30px;
         margin-top: 10px;
         margin-bottom: 10px;
         }
-    
+
     .mainlist
-        {   
+        {
         margin-top: 10px;
         margin-left: 50px;
         margin-bottom: 10px;
         }
     .mainlist li
         {
-        list-style-type:disc;   
+        list-style-type:disc;
         }
-        
+
     .taglist
-        {   
-        margin-top: 10px;   
+        {
+        margin-top: 10px;
         margin-left: 50px;
         margin-bottom: 10px;
-        }   
+        }
     .taglist li
         {
-        display:inline; 
-        list-style: none; 
+        display:inline;
+        list-style: none;
         padding-left: 7px;
         }
     .bodylist
-        {   
-        margin-top: 5px;    
+        {
+        margin-top: 5px;
         margin-left: 50px;
         margin-bottom: 5px;
-        }   
+        }
     .taglist li
         {
         list-style-type:disc;
-        }   
-        
+        }
+
     ul{padding-left: 30px; list-style:disc;}
-    
+
     ol{padding-left: 30px; list-style-type:lower-alpha}
-    
+
     .twitterBlock
         {
-        margin-left: 50px; 
+        margin-left: 50px;
         }
-    
-    </style>  
-  
+
+    </style>
+
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 {% include top.html %}
 
 <body class="home blog two-col-left width-940 two-col-left-940" onload="checkLinkRot();">
-    
+
   {% include header.html %}
 
     <div class="page-header">
@@ -23,7 +23,7 @@
           {% else %}
             <li class="prev disabled"><a>&larr; Previous</a></li>
           {% endif %}
-            
+
           {% if page.next %}
             <li class="next"><a href="{{ BASE_PATH }}{{ page.next.url }}" title="{{ page.next.title }}">Next &rarr;</a></li>
           {% else %}
@@ -32,15 +32,15 @@
           </ul>
         </div>
     </div>
-    
+
     <hr />
     <!-- 3scale -->
     <p align="center">
-        <a href="http://bit.ly/13esk6Q" target="_blank" title="APIs From 3Scale">
+        <a href="https://bit.ly/13esk6Q" target="_blank" title="APIs From 3Scale">
             <img src="https://s3.amazonaws.com/kinlane-productions/api-service-providers/3Scale/empowered-by-3scale.png" width="300" style="padding-bottom: 15px;" />
-        </a>        
-    </p>     
-    
+        </a>
+    </p>
+
     <center>
     <hr />
     <table width="100%" border="0" style="margin-top: -8px; margin-bottom: 12px;">
@@ -48,22 +48,22 @@
             <td style="width: 70px;" align="center">
                 <!-- Place this tag in your head or just before your close body tag -->
                 <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>
-                
+
                 <!-- Place this tag where you want the +1 button to render -->
-                <g:plusone size="medium"></g:plusone>                       
+                <g:plusone size="medium"></g:plusone>
             </td>
             <td style="width: 70px;" align="center">
-                <a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="apievangelist">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>                           
-            </td>                           
+                <a href="https://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="apievangelist">Tweet</a><script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
+            </td>
             <td style="width: 90px;">
                 <div style="padding-bottom:-9px;">
-                <script type="text/javascript" src="http://platform.linkedin.com/in.js"></script>
+                <script type="text/javascript" src="https://platform.linkedin.com/in.js"></script>
                 <script type="in/share" data-counter="right"></script>
                 </div>
-            </td>                           
+            </td>
             <td style="margin-top:25px; width: 90px;">
-                <!-- AddThis Button BEGIN -->               
-                
+                <!-- AddThis Button BEGIN -->
+
                 <div class="addthis_toolbox addthis_default_style " align="center" style="width: 100px; margin-top: 10px; padding-bottom: 1px; margin-left: 20px;">
                 <a class="addthis_button_preferred_1"></a>
                 <a class="addthis_button_preferred_2"></a>
@@ -72,31 +72,31 @@
                 <a class="addthis_button_preferred_5"></a>
                 </div>
                 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
-                <script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid=kinlane"></script>
+                <script type="text/javascript" src="https://s7.addthis.com/js/250/addthis_widget.js#pubid=kinlane"></script>
                 <!-- AddThis Button END -->
-                                        
-                
+
+
             </td>
         </tr>
     </table>
-    </center>   
+    </center>
     <hr />
-    
+
     <div id="disqus_thread"></div>
     <script type="text/javascript">
-    
+
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
         var disqus_shortname = 'apievangelist'; // required: replace example with your forum shortname
-    
+
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 
   {% include footer.html %}
 

--- a/about.json
+++ b/about.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "LinkedIn",
-      "url": "http://www.linkedin.com/in/kinlane"
+      "url": "https://www.linkedin.com/in/kinlane"
     },
     {
       "name": "Google+",

--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -3,19 +3,19 @@
        {
             "title": "3Scale",
             "tagline": "API Management",
-            "url": "http://bit.ly/13esk6Q",
-            "logo": "http://kinlane-productions.s3.amazonaws.com/api-service-providers/3scale-logo.jpg",
+            "url": "https://bit.ly/13esk6Q",
+            "logo": "https://kinlane-productions.s3.amazonaws.com/api-service-providers/3scale-logo.jpg",
             "width": "200",
              "paddingbottom": "10"
-        },                                                           
+        },
         {
             "title": "Restlet",
             "tagline": "Comprehensive solution for all your RESTful web API needs.",
-            "url": "http://bit.ly/1sgwGpq",
+            "url": "https://bit.ly/1sgwGpq",
             "logo": "https://s3.amazonaws.com/kinlane-productions/api-service-providers/api-spark/Logo-Restlet-Horizontal-800x225.png",
             "width": "200",
              "paddingbottom": "10"
-        }        
-               
+        }
+
     ]
 }

--- a/index.html
+++ b/index.html
@@ -5,19 +5,19 @@ overview: true
 ---
 
 <h2>What Is An API?</h2>
-<p>An API -- Application Programming Interface -- at its most basic level, allows your product or service to talk to other products or services. In this way, an API allows you to open up data and functionality to other developers, to other businesses or even between departments and locations within your company. It is increasingly the way in which companies exchange data, services and complex resources, both internally, externally with partners, and openly with the public.</p>                                       
-                                            
+<p>An API -- Application Programming Interface -- at its most basic level, allows your product or service to talk to other products or services. In this way, an API allows you to open up data and functionality to other developers, to other businesses or even between departments and locations within your company. It is increasingly the way in which companies exchange data, services and complex resources, both internally, externally with partners, and openly with the public.</p>
+
 <h2>What Are APIs Used For?</h2>
 <p>APIs are launched primarily to give partners that are outside the company firewall, access to internal data and resources. But recently, APIs are also being used by more of the general public, including non-developers. As APIs' ease-of-use and popularity increases -- and as APIs demonstrate their value and deliver efficiencies -- many companies have begun to consume their own APIs to build internal systems, websites, and mobile apps using the same APIs that they make available to third-party developers and to the public.</p>
 <p>APIs are a single endpoint, for programmatic access to a resource, that can be secured and tailored for different uses. APIs originally were used to enable integration with distributed sites and systems by companies like Salesforce, Amazon and Ebay, but newer companies quickly realized APIs would enable new types of relationships, making the web much more social.</p>
 <p>Alongside this evolution in API usage, one of the early pioneers Amazon, was working on a new approach to using APIs to deploy infrastructure, now known as Cloud Computing. These APIs have forever changed how we build applications, just in time for a new way to use applications via our mobile phones. </p>
-<p>In 2013, the number one reason APIs are deployed, is to support mobile development. While APIs can be used for commerce, payments, social, cloud computing and much more, mobile phones and tablets are the biggest driving force for providing APIs and consuming them.</p>                                       
-                                            
+<p>In 2013, the number one reason APIs are deployed, is to support mobile development. While APIs can be used for commerce, payments, social, cloud computing and much more, mobile phones and tablets are the biggest driving force for providing APIs and consuming them.</p>
+
 <h2>Why Do You Need An API?</h2>
 <p>An API is the cornerstone of what is widely seen as the next iteration of business development, where having a well-developed API is poised to be the way in which business relationship are established and maintained in a online, 24/7 digital economy. A decade ago, businesses were still working to understand the importance of having a website for doing business. Today, businesses are beginning to understand the similar importance in having an API.</p>
 <p>Whether your API provides programmatic access to information that is already on your website like company directory or product catalog, providing secure access to trusted partners, an APIs is becoming essential for operating in current markets, and effectively competing.</p>
-<p style="page-break-after: always;">You currently put products and services on the Internet for your human consumers to access in the form of websites and applications. APIs are the wholesale version of a web presence, allowing others to access and integrate your data and resources into their public or private sites and applications.</p>                                        
-                                            
+<p style="page-break-after: always;">You currently put products and services on the Internet for your human consumers to access in the form of websites and applications. APIs are the wholesale version of a web presence, allowing others to access and integrate your data and resources into their public or private sites and applications.</p>
+
 <h2>History of Modern Web APIs</h2>
 <p>APIs have been around since the 1980s, when they were used in hardware and software development. However, the history of the modern Web API is fairly short -- just a little over ten years. There are several pioneers of Web APIs, and while they didn't necessarily invent any of the technologies at play here, they did popularize their usage and establish some of the common practices.</p>
 <h3>First Mover</h3>
@@ -74,8 +74,8 @@ overview: true
 </tr>
 </tbody>
 </table>
-<p style="page-break-after: always;">Many of these pioneers have shaped the way in which we develop, deploy, consume, and support APIs, sparking a lot of innovation within the API space in the last decade.</p>                                       
-                                            
+<p style="page-break-after: always;">Many of these pioneers have shaped the way in which we develop, deploy, consume, and support APIs, sparking a lot of innovation within the API space in the last decade.</p>
+
                             <h2>What Technology Goes Into An API?</h2>
 <p>APIs are driven by a set of specific technologies, making them easily understood by developers.&nbsp; This type of focus means that APIs can work with any common programming language, with the most popular approach to delivering web APIs being REST, or&nbsp;REpresentational State Transfer.</p>
 <p>REST takes advantage of the same Internet mechanisms that are used to view regular web pages, giving it many advantages, that can result in faster implementations and easier for developers to understand and use. REST APIs allow you to take data and functionality that may already be available on your website and make them available through a programmatic API, that both web and mobile applications can use. Then, instead of returning HTML to represent the information like a website would, an API returns data in one of two possible formats:</p>
@@ -89,15 +89,15 @@ overview: true
 <li>OAuth</li>
 </ul>
 <p>REST with JSON has become the favorite of developers and API owners, because it is easier to both deploy and consume than other implementations. Even though REST + JSON is not a standard, it is seeing wide acceptance across the industry.</p>
-<p>The technology that are commonly found in APIs was not designated by a single standards body or by a single company, it is based upon emulating the best practices of existing, successful providers over the last 13 years.</p>                                     
-                                            
+<p>The technology that are commonly found in APIs was not designated by a single standards body or by a single company, it is based upon emulating the best practices of existing, successful providers over the last 13 years.</p>
+
                             <h2>API Design</h2>
 <p>Designing APIs has evolved over the last decade and is becoming a highy skilled craft. APi design is about applying forward thinking about how an API will be used and evolve over time, API deployment and management experience, allof which can go a long way in avoiding common pitfalls and ultimately saving time, money and headache.</p>
 <p>In the past, API design was something developers did, and with the emergence of new approaches to API definitions like <a href="https://developers.helloreverb.com/swagger/">Swagger</a> and <a href="https://github.com/mashery/iodocs">Mashery I/O Docs</a>, and from service providers like <a href="http://apiary.io">Apiary.io</a>, API design can truly be planned, designed and mocked up to find the most meaningful interfaces possible--before implementation.</p>
 <p>Web APIs use URLs, but to find the most meaningful strategy, sensible uses of HTTP verbs like GET, POST, PUT and DELETE, requires deep consideration about how a resource will be manipulated via a URL, not just retrieved. Then also providing a robust set of parameters and default values that will help make an API intuitive to use.</p>
 <p>API design is often done in the trenches of API operations, iterating and perfecting as an API iniative evolves. However with a growing base of API expertise and design tools many API craftsmen are spending time designing the perfect interface before even writing a line of code.</p>
-<p>Quality API design is proving to to be one of the best ways to mitigate risk, and help cost effectively execute on an API initative, wile also delivering the most value to end users.</p>                                       
-                                            
+<p>Quality API design is proving to to be one of the best ways to mitigate risk, and help cost effectively execute on an API initative, wile also delivering the most value to end users.</p>
+
                             <h2>API Deployment</h2>
 <p>Deploying APIs is sitll something that can be very technical, requiring a healthy understanding of what an API is, how to construct a RESTful framework, and deploy the APIs underlying architecture. However with the growing demand for APIs and the potential for new service providers entering the space, we are seeing more tools and services available for assisting providers in deployment of web APIs in 2013.</p>
 <p>When it comes to API deployment it is all about what resources you have. If you have technical talent within reach, that understands APIs and can custom design and deploy APIs--this is the route to take. However as many companies are finding, they have the need, but no the resources to actually execute on the designing and deployment of APIs.&nbsp;&nbsp;</p>
@@ -106,11 +106,11 @@ overview: true
 <p><strong>API as a Service</strong><br />Cloud providders are also emerging that assist companies in deploying APIs from common data source such as from MySQL, SQL Server, PostGreSQL, Oracle and even new sources such as NosQL or cloud computing databases. If your need to deploy APIs is centered around resources available within existing data sources, take a ook at the range of existing services that are emerging to help companies deploy APIs.</p>
 <p><strong>Custom Deployment</strong><br />Many companies will opt for deploying their own custom API platforms. Even if your company has the resources available to design develop your own custom APIs, there are plenty of REST frameworks, oAuth servers and other open resources to help get the job done.&nbsp; There is no reason to reinvent the wheel with the wealth of custom API deployment resources currently available.</p>
 <p>In the last six years, the case has been made for APIs. API pioneers have laid the groundwork proving the value is there, and now it is time to refine and establish best practices of API deployment using common, open source frameworks and common patterns like REST, and Hypermedia.&nbsp;</p>
-<p style="page-break-after: always;">Good API design will make API deployment a sensible and efficient process. But even with deployment, the job isn't done and following well established practices for API management is next.</p>                                       
-                                            
+<p style="page-break-after: always;">Good API design will make API deployment a sensible and efficient process. But even with deployment, the job isn't done and following well established practices for API management is next.</p>
+
                             <h2>Essential Building Blocks for API Providers</h2>
 <p>After 13 years of web API history, a common set of building blocks that are essential to API adoption have emerged. The following elements have become common across top providers, as part of their developer portals and developer outreach efforts:</p>
-<p><img src="http://kinlane-productions.s3.amazonaws.com/api-evangelist/building%20blocks.jpg" alt="" width="250" align="right" /></p>
+<p><img src="https://kinlane-productions.s3.amazonaws.com/api-evangelist/building%20blocks.jpg" alt="" width="250" align="right" /></p>
 <ul class="mainlist">
 <li>Overview / Landing Page</li>
 <li>Getting Started</li>
@@ -125,15 +125,15 @@ overview: true
 </ul>
 <p>API pioneers like Ebay, Salesforce, Flickr, Google and Twilio have established this common set of essential API building blocks through trial and error over the last decade.</p>
 <p>These are not anything new, but very simple approaches to helping on-board developers and consumers of an API in the quickest way possible, while also building a platform that can support hundreds or thousands of consumers and support an active community around an API.</p>
-<p>Some building blocks work best for some providers over others, but these ten building blocks can be considered essential to API deployment and management.</p>                                       
-                                            
+<p>Some building blocks work best for some providers over others, but these ten building blocks can be considered essential to API deployment and management.</p>
+
                             <h2>API Management</h2>
 <p>Each of the pioneering API providers have established their own approach to API management through trial and error. But with the help of API management providers like <a href="http://3scale.net">3Scale</a>, <a href="http://apigee.com">Apigee</a>, <a href="http://mashery.com">Mashery</a>, there is no shortage of API management services available on the market today for people looking to get into the game.</p>
 <p>API management is not usally about a single API, but providing a portal where private, partner and public developers can access a wide variety of API resources to use in many different applications. Common building blocks have merged for delivering API resources to consumers, but exactly how you implement the technology and business operations of your API can be a significant amount of work.</p>
 <p>Some API providers cobble together their API management using existing SaaS and PaaS or their existing hosting situation. They will bind disparate service like Google Groups, Wordpress and Github into a web of online resources intended to deliver an API portal on a budget.</p>
 <p>Other companies use existing API management as a service providers like <a href="http://3scale.net">3Scale</a> or <a title="Apiphany" href="http://apiphany.com">Apiphany</a>. These companies bring the tools, resources and experience necessary to go from 0 to 60 in any API management campaign without reinventing the wheel, while also taking advantage of existing best practices.</p>
-<p>API management has been well established in the last 3 years, if you have the resources to do yourself, at least take the time to understand what has been done to date, and do your homework on best practices of API management. If you do not have the experiece and resources make sure and talk to one of the many API management providers currently available. They can help.</p>                                     
-                                            
+<p>API management has been well established in the last 3 years, if you have the resources to do yourself, at least take the time to understand what has been done to date, and do your homework on best practices of API management. If you do not have the experiece and resources make sure and talk to one of the many API management providers currently available. They can help.</p>
+
                             <h2>API Monetization</h2>
 <p>Hopefully by the time you have put an API management plan in place, you already have a health business model in place, which should provide framework for you monetization goals.</p>
 <p>Its not just about how you are going to generate revenue via your API, it is also about how you will keep your API in operation, and performing for consumers.</p>
@@ -163,8 +163,8 @@ overview: true
 <p>Many companies start by focusing on launching and evolving their API strategy and gaining essential experience, before fully executing on their API monetization strategy--relying completely on indriect value from an API. While it is better to have a monetization strategy in place early, many are finding success by prioritizing the API first and monetziation second.</p>
 <p class="p1">With APIs being deployed in various capacities, within a company, privately between partners or in the public, a wide mix of monetization strategies can be used. Some API resources just lend themselves better to a pay as you go model, while some markets demand that data be freely accessible with the need to register or be charged for access. There is no one size fits all approach to API monetization.</p>
 <p class="p1">One way to think about an API is as an external research &amp; development lab within a company. A lab that accepts ideas and integrations from partners, incubates these ideas, applications and business relationships. Companies are using APIs to bring allow the introduction of outside ideas and talent into the mix, in hopes of inciting innovation. Some API providers will hand select the best integrations, invest in their individuals and companies, sometimes resulting in acquisitions of technology and the talent they possess--creating entirely new approaches to monetization you may not have thought of.</p>
-<p style="page-break-after: always;">Just like there is no on size fits all approach to API monetization, there are few constants in pricing or access. Even the pioneers in the space like Amazon Web Services are constantly adjusting, tweeking and experitmenting, trying to find the most competitive approach possible. APIs are about business development and finding new ways to monetize your new and existing resources.</p>                                     
-                                            
+<p style="page-break-after: always;">Just like there is no on size fits all approach to API monetization, there are few constants in pricing or access. Even the pioneers in the space like Amazon Web Services are constantly adjusting, tweeking and experitmenting, trying to find the most competitive approach possible. APIs are about business development and finding new ways to monetize your new and existing resources.</p>
+
                             <h2>API Evangelism</h2>
 <p>An API is useless if nobody knows about it. Evangelism has emerged as the approach to selling, marketing and support an API platform. While the intent of evangelism can be sales and marketing, the philosphy that has proved successful is to find a balance that is more about focusing on API support and egagement with consumers over sales.</p>
 <p>A healthy API evangelism strategy brings together a mix of business, marketing, sales and technology disciplines into a new approach to doing business.</p>
@@ -181,37 +181,37 @@ overview: true
 <p><strong>Reporting</strong><br />Measuring every aspect of an API operations is necessary to understand what is happening in any API operations. Reporting on every aspect of API operations is how you visualize and make sense of some often, very fast moving API activity. It is important to quantify API operations, and develop reports that are crafted to inform key stakeholders about an API initiative. </p>
 <p><strong>Internal</strong><br />External facing activities will dominate any active API operations. However, an essential aspect of sustainable API programs is internal evangelism. Making sure co-workers across all departments are aware and intimate with API operations, while also informing management, leadership and budget decision makers is critical to keeping API doors open, healthy and active.&nbsp;</p>
 <p><strong>Repeat</strong><br />API and developer evangelism is an iterative cycle. Successful API operations will measure, assess and plan for the roadmap in an ongoing fashion, often repeating on a weekly and monthly basis to keep cycles small, reducing the potential for friction in operations and minimizing failures when they happen.</p>
-<p>A healthy API evangelism strategy will be something that is owned partially by all departments in a company. IT was a silo, APIs are about interoperability internally and externally.</p>                                       
-                                            
+<p>A healthy API evangelism strategy will be something that is owned partially by all departments in a company. IT was a silo, APIs are about interoperability internally and externally.</p>
+
                             <h2>API Discovery</h2>
 <p>In the early days of the web API movement (2005-2010), to find APIs, you went to <a href="http://programmableweb.com">ProgrammableWeb</a> (PW), which was the only site on the web that was exclusively dedicated to web APIs. Discovery happened via the PW directory and constant stream of news and analysis about the space.</p>
 <p>ProgrammableWeb is still relevant in 2013, but as the number of APIs grows, the directory model is not meeting the demand for finding the best of breed APIs that developers are needing to build web and mobile apps.</p>
 <p>Within the API tech sector there has always discussion around the need for programatic discovery of APIs. Something that uses a machine readable approach to describing APIs, so that the next generation of API directories, integrated development environments (IDE) and other systems can discover, understand, monitor and integrate with APIs--with less human involvement. In short, this vision has never been realized.</p>
 <p>API discovery has two sides, finding the APIs you need and having your API be found. While there has been an evolution in the API discovery game, much of it is still done manually, with a lot of legwork by both API providers and consumers.</p>
-<p>As we move beyond 10K public APIs in the original API directory at ProgrammableWeb, the need for solid approaches to API discovery will emerge. API discovery is the bridge between API provider and consumer.</p>                                       
-                                            
+<p>As we move beyond 10K public APIs in the original API directory at ProgrammableWeb, the need for solid approaches to API discovery will emerge. API discovery is the bridge between API provider and consumer.</p>
+
                             <h2>API Integration</h2>
 <p>Integrating with a single API can be tough, let alone multiple APIs. API integration involves on-boarding, exploration, education, authentication, code samples, testing, monitoring and sandboxing. An average API integration project involves everything between the discovery of APIs and when the application goes into production.</p>
 <p>As the average web or mobile application evolves from using one or two APIs, to potential 10 or 20, the need to escalate and streamline the integration will become critical. Developers are already feeling the pain, and a new breed of API integration services and tools are emerging to meet the demand.</p>
 <p>This new breed of API service providers are looking to aid developers in finding the best of breed APIs, learn about how they work, and get up and running as fast as possible.</p>
 <p>Once a developer has successfully integrated with API resources, there is a transition from integration to operation, and a whole other opportunity to provide tools and services that will ensure success for developers.&nbsp;</p>
-<p>API integration has moved beyond the hobby mashup and the challenges of single API integration, and is becoming about building essential applications around mission critical, API driven resources that reside internally, via partner systems and across the Internet.</p>                                     
-                                            
+<p>API integration has moved beyond the hobby mashup and the challenges of single API integration, and is becoming about building essential applications around mission critical, API driven resources that reside internally, via partner systems and across the Internet.</p>
+
                             <h2>API Ecosystem</h2>
 <p>APIs start with deploying an API area to hang and manage a handful of APIs, where they can be accessed and put to use by consumers. But the goal is take an API area, evolve it into an active community of API consumers in hopes of transforming it into a self service, self managing ecosystem of passionate partners and consumers.</p>
 <p>Sustainable API ecosystems are a two way street. They are not just about about API providers generating value, it is also about API consumers getting the resources they need to be successful and engaging in a new approach to busines development.</p>
 <p>An API ecosystem will start within a single portal of API providers and consumers working together, but an ecosystem will never exist in just a single place. In this new connected world, API ecosystems will exit on Twitter, Stack Exchange, Quora and anywhere else an API consumer will frequent.</p>
 <p>Developing and growing an API from area to ecosystem takes years of work, lots of communication, support and hustle by everyone invovled. An active API will attract new users, and the users who get the value they are looking for, and the support they need, will ultimately spread the word. </p>
 <p>A viable API ecossystem is equal parts technology, business and politics. A balance will need to be struck that doesn't just deliver value for API providers and consumers, but also end users of any web or mobile apps that are integrated with API resources.</p>
-<p>We all want an ecosystem around our API, but few of use will actually achive one.</p>                                        
-                                            
+<p>We all want an ecosystem around our API, but few of use will actually achive one.</p>
+
                             <h2>What Are The Benefits of An API</h2>
 <p>The most direct benefits of an API are quicker, easier and more re-usable technical access to your companies assetts and resources. APIs will allow your company to rapidly develop web, mobile and tablet applications from a single technical stack of machine readable resources. </p>
 <p>Using an API, you will be able to take better advantage of outside and 3rd party resources. Giving developers access to only the resources they need to build applications that will be used to expand the reach of a business. It is the perfect balance of opening up access to your resources while also keeping things secure, and within control. This will allow a company to eliminate traditional IT resource bottlenecks, in a sensible way.&nbsp;</p>
 <p>Beyond the technical benefits of an API, an API can bring an entirely new way of thinking to your business operations. APIs will allow you to think differently about your companies most valuable assets and resources, enabling you to decouple them and allow them to be used indpenedntly and in new ways you never imagined before. As you take inventory and prepare your resources to be deployed as APIs, it will give you a new way of looking at a way of operating that encourages transparency, interoperability and scalability by default, without costing you security.</p>
-<p>This will ultimately transform business operations more agile, nimble and flexibile and able to take on any challenge in this new digital economy. </p>                                        
-                                
-                                            
+<p>This will ultimately transform business operations more agile, nimble and flexibile and able to take on any challenge in this new digital economy. </p>
+
+
                             <h2>APIs Are Growing Part Our Connected World</h2>
 <p>In 1995 the question was, should we have a website?  By 2000 it was clear, to compete in business you had to have a website.  By 2010 the question was, should we have an API?  And by 2015 it will be mandatory for business to have an API or they won't be able to compete in this new global, API driven landscape.</p>
 <p>Our business worlds moved online by 2000, by 2005 things were getting social, then with introduction of cloud computing we were able to start delivering the scalable resources we would need to power the next generation of computing, via mobile smart phones. All of this is made possible by APIs, delivering the modular, valuable resources that are needed to build web, mobile and tablet sites and applications the world demands.</p>
@@ -226,6 +226,6 @@ overview: true
 <p align="center">
 <a href="http://3scale.net" target="_blank" title="APIs From 3Scale">
     <img src="https://s3.amazonaws.com/kinlane-productions/api-service-providers/3Scale/empowered-by-3scale.png" width="300" style="padding-bottom: 15px;" />
-</a>        
+</a>
 </p>
-<!-- 3scale -->     
+<!-- 3scale -->

--- a/network.html
+++ b/network.html
@@ -44,10 +44,10 @@ overview: true
 
 <img id="Image-Maps-Com-image-maps-2014-04-03-123401" src="https://s3.amazonaws.com/kinlane-productions/api-evangelist/api-evangelist-metro-map-other.png" border="0" width="575" height="431" orgWidth="575" orgHeight="431" usemap="#image-maps-2014-04-03-123401" alt="" />
 <map name="image-maps-2014-04-03-123401" id="ImageMapsCom-image-maps-2014-04-03-123401">
-<area  alt="" title="3D Printing" href="http://bit.ly/1hoAwYg" shape="rect" coords="84,85,194,114" style="outline:none;" target="_self"     />
-<area  alt="" title="Automobile" href="http://bit.ly/19IDnrj" shape="rect" coords="87,152,197,181" style="outline:none;" target="_self"     />
-<area  alt="" title="Home" href="http://bit.ly/17uu35X" shape="rect" coords="88,224,198,251" style="outline:none;" target="_self"     />
-<area  alt="" title="Buildings" href="http://bit.ly/12yPjC8" shape="rect" coords="87,286,197,317" style="outline:none;" target="_self"     />
+<area  alt="" title="3D Printing" href="https://bit.ly/1hoAwYg" shape="rect" coords="84,85,194,114" style="outline:none;" target="_self"     />
+<area  alt="" title="Automobile" href="https://bit.ly/19IDnrj" shape="rect" coords="87,152,197,181" style="outline:none;" target="_self"     />
+<area  alt="" title="Home" href="https://bit.ly/17uu35X" shape="rect" coords="88,224,198,251" style="outline:none;" target="_self"     />
+<area  alt="" title="Buildings" href="https://bit.ly/12yPjC8" shape="rect" coords="87,286,197,317" style="outline:none;" target="_self"     />
 <area  alt="" title="Quantified Self" href="http://apievangelist.com/opportunities/quantified-self.php" shape="rect" coords="88,363,198,394" style="outline:none;" target="_self"     />
 <area  alt="" title="Federal Government" href="http://federal-government.apievangelist.com/" shape="rect" coords="313,84,462,115" style="outline:none;" target="_self"     />
 <area  alt="" title="City Government" href="http://city-government.apievangelist.com/" shape="rect" coords="312,135,461,166" style="outline:none;" target="_self"     />
@@ -55,7 +55,7 @@ overview: true
 <area  alt="" title="University" href="http://university.apievangelist.com/" shape="rect" coords="312,244,461,275" style="outline:none;" target="_self"     />
 <area  alt="" title="Education" href="http://education.apievangelist.com/" shape="rect" coords="312,299,461,330" style="outline:none;" target="_self"     />
 <area  alt="" title="Healthcare" href="http://healthcare.apievangelist.com/" shape="rect" coords="311,360,460,391" style="outline:none;" target="_self"     />
-<area shape="rect" coords="573,429,575,431" alt="Image Map" style="outline:none;" title="Image Map" href="http://www.image-maps.com/index.php?aff=mapped_users_13658" />
+<area shape="rect" coords="573,429,575,431" alt="Image Map" style="outline:none;" title="Image Map" href="https://www.image-maps.com/index.php?aff=mapped_users_13658" />
 </map>
 
 </div>
@@ -63,7 +63,7 @@ overview: true
 <hr />
 <!-- 3scale -->
 <p align="center">
-    <a href="http://bit.ly/13esk6Q" target="_blank" title="APIs From 3Scale">
+    <a href="https://bit.ly/13esk6Q" target="_blank" title="APIs From 3Scale">
         <img src="https://s3.amazonaws.com/kinlane-productions/api-service-providers/3Scale/empowered-by-3scale.png" width="300" style="padding-bottom: 15px;" />
-    </a>        
-</p> 
+    </a>
+</p>


### PR DESCRIPTION
I was interested in what it would take to move the site to HTTPS, so I ran the app using [ngrok](https://ngrok.com/) and fixed up some mixed content warnings by turning various `http://` URLs into `https://` URLs. I also did a scan of lots of other `http://` URLs used in different data objects and stuff, and turned them into `https://` where appropriate.

I only touched index, layout, and data stuff, not individual post pages, so there may be mixed content warnings from images/embeds in individual posts.

The main thing I couldn't fix was the linkrot API call, which is not available over HTTPS (and which seems to 500 out when not POSTed to from a whitelisted domain).

![errors](https://cloud.githubusercontent.com/assets/4592/4345551/a517e7ec-40d4-11e4-9730-fc6af7cc2f21.png)

(The 404 is a separate problem, and exists on the live site already.)
